### PR TITLE
Add notifications for task sharing and contributor updates

### DIFF
--- a/app/Livewire/ContributorSelector.php
+++ b/app/Livewire/ContributorSelector.php
@@ -4,6 +4,7 @@ namespace App\Livewire;
 
 use App\Models\Task;
 use App\Models\User;
+use App\Notifications\SharedTask;
 use Illuminate\Support\Facades\Validator;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
@@ -65,6 +66,8 @@ class ContributorSelector extends Component
             'user_id' => $contributorUser->id,
             'role' => $this->role,
         ]);
+
+        $contributorUser->notify(new SharedTask($this->task));
     }
 
     public function removeContributor(string $email)

--- a/app/Notifications/SharedTask.php
+++ b/app/Notifications/SharedTask.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Task;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class SharedTask extends Notification
+{
+    use Queueable;
+
+    public function __construct(public Task $task) {}
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Task shared with you')
+            ->from(config('mail.from.address'), $this->task->user->name)
+            ->greeting('Hello '.$notifiable->name)
+            ->line('A task has been shared with you')
+            ->action('View Task', route('tasks.show', $this->task->id))
+            ->line('Thank you for using our application!');
+    }
+}


### PR DESCRIPTION
Introduce email notifications for users when a task is shared and when a contributor is added to a task.